### PR TITLE
Fix task generator route header

### DIFF
--- a/app/api/tasks/gen/route.ts
+++ b/app/api/tasks/gen/route.ts
@@ -1,5 +1,4 @@
 export const runtime = "nodejs" // Force Node.js runtime, disable edge
-
 import { NextResponse } from "next/server"
 import { supabase } from "@/lib/supabaseClient"
 import { generateText } from "ai"


### PR DESCRIPTION
## Summary
- remove stray blank line at the top of `app/api/tasks/gen/route.ts`
- confirm tasks generate in demo mode

## Testing
- `npx tsx -e "import { POST } from './app/api/tasks/gen/route'; (async()=>{const req=new Request('http://localhost',{method:'POST',body:JSON.stringify({module_id:'mod123'})}); const res=await POST(req); console.log('status',res.status); const text=await res.text(); console.log(text);})();"`

------
https://chatgpt.com/codex/tasks/task_e_6889bf11cdb4832689f3a3c47de61453